### PR TITLE
fix: get accurate pr history oldest to newest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cherri",
     "description": "Automated cherry-picking for PRs",
-    "version": "1.1.5",
+    "version": "1.2.1",
     "main": "dist/index.js",
     "license": "MIT",
     "files": [


### PR DESCRIPTION
Turns out the /search/issues PR doesn't return enough info about the merged_at, so we need to call this endpoint to get all info regarding the PR.